### PR TITLE
Open Software Center as a snap

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -40,7 +40,7 @@ let extension;
 let list = [
 { type: "command",	  text: _("About This Computer"), action: ['gnome-control-center', 'info-overview']},
 { type: "desktop",	  text: _("Software Update"), action: 'update-manager.desktop'},
-{ type: "desktop",	  text: _("Software Center"), action: 'org.gnome.Software.desktop'},
+{ type: "command",	  text: _("Software Center"), action: ['env', 'BAMF_DESKTOP_FILE_HINT=/var/lib/snapd/desktop/applications/snap-store_ubuntu-software.desktop', '/snap/bin/snap-store.ubuntu-software']},
 { type: "separator"},
 { type: "command",	   text: _("System Preferences"), action: ['gnome-control-center', '']},
 { type: "desktop",	   text: _("Gnome Tweak Tool"), action: 'org.gnome.tweaks.desktop'},

--- a/metadata.json
+++ b/metadata.json
@@ -8,9 +8,13 @@
     "3.22",
     "3.24",
     "3.26",
-    "3.28"
+    "3.28",
+    "3.30",
+    "3.32",
+    "3.34",
+    "3.36"
   ],
   "url": "http://github.com/jonnius/gnome-system-menu",
   "uuid": "SystemMenu@jonnius.github.com",
-  "version": 3
+  "version": 4
 }


### PR DESCRIPTION
Replaces the gnome software desktop file by a command to launch Ubuntu Software which is installed as a snap.