### PR TITLE
Removed tweener import

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -22,7 +22,6 @@ const Main = imports.ui.main;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const Panel = imports.ui.panel;
-const Tweener = imports.ui.tweener;
 const GnomeSession = imports.misc.gnomeSession;
 const LoginManager = imports.misc.loginManager
 


### PR DESCRIPTION
Removed tweener import which is not used and also breaks the extension on gnome shell 3.38.1.